### PR TITLE
Resolves #29 match colors, spacing, typography to design system

### DIFF
--- a/src/__tests__/Link.js
+++ b/src/__tests__/Link.js
@@ -92,7 +92,7 @@ describe('Link', () => {
     expect(renderJSON(<Link as="button">APPLY</Link>)).toMatchSnapshot();
 
     const { container } = render(<Link as="button" />);
-    expect(container.firstChild).toHaveStyle(`font-family: ${theme.typography.button.font}`);
+    expect(container.firstChild).toHaveStyle(`font-family: ${theme.typography.button.fontFamily}`);
     expect(container.firstChild).toHaveStyle(`font-size: ${theme.typography.button.fontSize}`);
     expect(container.firstChild).toHaveStyle(`letter-spacing: ${theme.typography.button.letterSpacing}`);
   });

--- a/src/__tests__/Link.js
+++ b/src/__tests__/Link.js
@@ -92,8 +92,8 @@ describe('Link', () => {
     expect(renderJSON(<Link as="button">APPLY</Link>)).toMatchSnapshot();
 
     const { container } = render(<Link as="button" />);
-    expect(container.firstChild).toHaveStyle(`font-family: ${theme.buttons.font}`);
-    expect(container.firstChild).toHaveStyle(`font-size: ${theme.buttons.fontSize}`);
-    expect(container.firstChild).toHaveStyle(`letter-spacing: ${theme.buttons.letterSpacing}`);
+    expect(container.firstChild).toHaveStyle(`font-family: ${theme.typography.button.font}`);
+    expect(container.firstChild).toHaveStyle(`font-size: ${theme.typography.button.fontSize}`);
+    expect(container.firstChild).toHaveStyle(`letter-spacing: ${theme.typography.button.letterSpacing}`);
   });
 });

--- a/src/__tests__/Text.js
+++ b/src/__tests__/Text.js
@@ -91,10 +91,6 @@ describe('Text types', () => {
     expect(container.firstChild).toHaveStyle(`line-height: ${theme.typography.body.lineHeight}`);
   });
 
-  it('renders "hero" properly', () => {
-    expect(renderJSON(<Text type="hero">Hello</Text>)).toMatchSnapshot();
-  });
-
   it('renders "overline" properly', () => {
     expect(renderJSON(<Text type="overline">Hello</Text>)).toMatchSnapshot();
   });

--- a/src/__tests__/__snapshots__/Card.js.snap
+++ b/src/__tests__/__snapshots__/Card.js.snap
@@ -93,10 +93,10 @@ exports[`Card renders entire card properly 1`] = `
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 20px;
-  -webkit-letter-spacing: 0.5px;
-  -moz-letter-spacing: 0.5px;
-  -ms-letter-spacing: 0.5px;
-  letter-spacing: 0.5px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
   line-height: 28px;
   color: #0A162A;
   margin-top: 8px;

--- a/src/__tests__/__snapshots__/Card.js.snap
+++ b/src/__tests__/__snapshots__/Card.js.snap
@@ -21,21 +21,22 @@ exports[`Card renders a <div> 1`] = `
 
 exports[`Card renders entire card properly 1`] = `
 .c8 {
-  font-family: Chivo;
-  font-weight: 700;
-  font-size: 14px;
-  -webkit-letter-spacing: 2px;
-  -moz-letter-spacing: 2px;
-  -ms-letter-spacing: 2px;
-  letter-spacing: 2px;
-  line-height: 20px;
-  text-transform: uppercase;
   -webkit-text-decoration: none;
   text-decoration: none;
   overflow: hidden;
   border-radius: 13px;
-  padding: 0px 32px;
-  height: 40px;
+  font-family: Chivo;
+  font-weight: 700px;
+  -webkit-letter-spacing: 2px;
+  -moz-letter-spacing: 2px;
+  -ms-letter-spacing: 2px;
+  letter-spacing: 2px;
+  font-size: 14px;
+  line-height: 20px;
+  padding: 12px 16px;
+  display: inline-block;
+  text-align: center;
+  vertical-align: middle;
   background: #155DA1;
   border: none;
   color: #FFFFFF;
@@ -168,6 +169,7 @@ exports[`Card renders entire card properly 1`] = `
     >
       <button
         className="c8"
+        type="medium"
       >
         Apply
       </button>

--- a/src/__tests__/__snapshots__/Tag.js.snap
+++ b/src/__tests__/__snapshots__/Tag.js.snap
@@ -24,7 +24,6 @@ exports[`Tag Colors renders blue dark 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #0E4E8A;
-  background-color: #0E4E8A;
 }
 
 <div
@@ -58,7 +57,6 @@ exports[`Tag Colors renders blue light 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #3E87CD;
-  background-color: #3E87CD;
 }
 
 <div
@@ -92,7 +90,6 @@ exports[`Tag Colors renders blue primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #155DA1;
-  background-color: #155DA1;
 }
 
 <div
@@ -126,7 +123,6 @@ exports[`Tag Colors renders green dark 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #256830;
-  background-color: #256830;
 }
 
 <div
@@ -160,7 +156,6 @@ exports[`Tag Colors renders green light 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #90E19E;
-  background-color: #90E19E;
 }
 
 <div
@@ -194,7 +189,6 @@ exports[`Tag Colors renders green primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #4C9859;
-  background-color: #4C9859;
 }
 
 <div
@@ -227,8 +221,7 @@ exports[`Tag Colors renders grey dark 1`] = `
   align-items: center;
   padding: 0px 8px;
   height: 28px;
-  background: #155DA1;
-  background-color: #155DA1;
+  background: #46494F;
 }
 
 <div
@@ -261,8 +254,7 @@ exports[`Tag Colors renders grey light 1`] = `
   align-items: center;
   padding: 0px 8px;
   height: 28px;
-  background: #EBEEF2;
-  background-color: #EBEEF2;
+  background: #8B9199;
 }
 
 <div
@@ -296,7 +288,6 @@ exports[`Tag Colors renders grey primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #666B72;
-  background-color: #666B72;
 }
 
 <div
@@ -330,7 +321,6 @@ exports[`Tag Colors renders indigo dark 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #253E68;
-  background-color: #253E68;
 }
 
 <div
@@ -364,7 +354,6 @@ exports[`Tag Colors renders indigo light 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #415F94;
-  background-color: #415F94;
 }
 
 <div
@@ -398,7 +387,6 @@ exports[`Tag Colors renders indigo primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #2D4979;
-  background-color: #2D4979;
 }
 
 <div
@@ -432,7 +420,6 @@ exports[`Tag Colors renders red dark 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #8A1A1F;
-  background-color: #8A1A1F;
 }
 
 <div
@@ -466,7 +453,6 @@ exports[`Tag Colors renders red light 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #D1595F;
-  background-color: #D1595F;
 }
 
 <div
@@ -500,7 +486,6 @@ exports[`Tag Colors renders red primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #A62B31;
-  background-color: #A62B31;
 }
 
 <div
@@ -534,7 +519,6 @@ exports[`Tag Colors renders yellow dark 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #DA9C03;
-  background-color: #DA9C03;
 }
 
 <div
@@ -568,7 +552,6 @@ exports[`Tag Colors renders yellow light 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #FFD15F;
-  background-color: #FFD15F;
 }
 
 <div
@@ -602,7 +585,6 @@ exports[`Tag Colors renders yellow primary 1`] = `
   padding: 0px 8px;
   height: 28px;
   background: #FDBE21;
-  background-color: #FDBE21;
 }
 
 <div

--- a/src/__tests__/__snapshots__/Text.js.snap
+++ b/src/__tests__/__snapshots__/Text.js.snap
@@ -119,27 +119,6 @@ exports[`Text types renders "form" properly 1`] = `
 </span>
 `;
 
-exports[`Text types renders "hero" properly 1`] = `
-.c0 {
-  color: #0A162A;
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 22px;
-  -webkit-letter-spacing: 0.5px;
-  -moz-letter-spacing: 0.5px;
-  -ms-letter-spacing: 0.5px;
-  letter-spacing: 0.5px;
-  line-height: 32px;
-}
-
-<span
-  className="c0"
-  type="hero"
->
-  Hello
-</span>
-`;
-
 exports[`Text types renders "overline" properly 1`] = `
 .c0 {
   color: #0A162A;
@@ -167,12 +146,12 @@ exports[`Text types renders "quote" properly 1`] = `
   color: #0A162A;
   font-family: HKGrotesk;
   font-weight: 300px;
-  font-size: 28px;
+  font-size: 22px;
   -webkit-letter-spacing: 0.5px;
   -moz-letter-spacing: 0.5px;
   -ms-letter-spacing: 0.5px;
   letter-spacing: 0.5px;
-  line-height: 40px;
+  line-height: 33px;
 }
 
 <span
@@ -189,10 +168,10 @@ exports[`Text types renders "subtitle" properly 1`] = `
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 20px;
-  -webkit-letter-spacing: 0.5px;
-  -moz-letter-spacing: 0.5px;
-  -ms-letter-spacing: 0.5px;
-  letter-spacing: 0.5px;
+  -webkit-letter-spacing: 1px;
+  -moz-letter-spacing: 1px;
+  -ms-letter-spacing: 1px;
+  letter-spacing: 1px;
   line-height: 28px;
 }
 

--- a/src/components/Tag/Tag.js
+++ b/src/components/Tag/Tag.js
@@ -25,7 +25,7 @@ const TagBase = styled.div`
     height: 28px;
 
     // color
-    background: ${(props) => props.backgroundColor};
+    background: ${(props) => props.background};
 
     ${COMMON};
     ${COLOR};
@@ -45,7 +45,7 @@ const Tag = ({
 
   return (
     <TagBase
-      backgroundColor={backgroundColor}
+      background={backgroundColor}
       textColor={textColor}
       theme={propTheme}
       {...props}

--- a/src/components/Text/Text.js
+++ b/src/components/Text/Text.js
@@ -31,7 +31,6 @@ Text.propTypes = {
   theme: PropTypes.object,
   type: PropTypes.oneOf([
     'body',
-    'hero',
     'caption',
     'overline',
     'button',

--- a/src/theme.js
+++ b/src/theme.js
@@ -8,8 +8,8 @@ const DEFAULT_SHADOW = '0 1px 6px 2px rgba(0,0,0,0.15)';
 
 const baseColors = {
   blue: ['#B4D8FA', '#3E87CD', '#155DA1', '#0E4E8A', '#0D3F6E', '#031425'],
-  indigo: ['#BCD0F3', '#415F94', '#2D4979', '#253E68', '#13294E', '#061734'],
-  grey: ['#FAFBFC', '#EBEEF2', '#8B9199', '#666B72', '#46494F'],
+  indigo: ['#7D9CD2', '#415F94', '#2D4979', '#253E68', '#13294E', '#061734'],
+  grey: ['#EBEEF2', '#8B9199', '#666B72', '#46494F', '#272A2D', '#4B4E52'],
 };
 
 const bluePalette = {
@@ -33,9 +33,10 @@ const indigoPalette = {
 const greyPalette = {
   lighter: baseColors.grey[0],
   light: baseColors.grey[1],
-  midtone: baseColors.grey[2],
-  primary: baseColors.grey[3],
+  primary: baseColors.grey[2],
+  dark: baseColors.grey[3],
   darker: baseColors.grey[4],
+  text: baseColors.indigo[5],
 };
 
 const secondaryColors = {
@@ -129,12 +130,14 @@ const fontWeights = {
   bold: 700,
 };
 
-const letterSpacings = ['0', '0.3px', '0.5px', '2px', '-0.15px'];
-letterSpacings.zero = letterSpacings[0]; // 0
-letterSpacings.third = letterSpacings[1]; // 0.3px
-letterSpacings.half = letterSpacings[2]; // 0.5px
-letterSpacings.two = letterSpacings[3]; // 22px
-letterSpacings.negFifteen = letterSpacings[4]; // -0.15px
+const letterSpacings = {
+  zero: '0',
+  third: '0.3px',
+  half: '0.5px',
+  one: '1px',
+  two: '2px',
+  negFifteen: '-0.15px',
+};
 
 // for a little better clarity
 // typography styles for table, forms, and alerts
@@ -142,7 +145,7 @@ const tableFormAlertStyle = {
   fontFamily: fonts.main,
   fontWeight: fontWeights.regular,
   fontSize: '18px',
-  letterSpacing: letterSpacings.third, // 0.3[x]
+  letterSpacing: letterSpacings.third, // 0.3px
   lineHeight: '24px',
 };
 
@@ -177,27 +180,19 @@ const typography = {
   },
 
   // Texts
+  subtitle: {
+    fontFamily: fonts.main,
+    fontWeight: fontWeights.regular,
+    fontSize: '20px',
+    letterSpacing: letterSpacings.one, // 0.5px
+    lineHeight: '28px',
+  },
   body: {
     fontFamily: fonts.main,
     fontWeight: fontWeights.regular,
     fontSize: '16px',
     letterSpacing: letterSpacings.third, // 0.3px
     lineHeight: '24px',
-  },
-  hero: {
-    fontFamily: fonts.main,
-    fontWeight: fontWeights.regular,
-    fontSize: '22px',
-    letterSpacing: letterSpacings.half, // 0.5px
-    lineHeight: '32px',
-  },
-  overline: {
-    fontFamily: fonts.main,
-    fontWeight: fontWeights.bold,
-    fontSize: '12px',
-    letterSpacing: letterSpacings.two, // 2px
-    lineHeight: '16px',
-    textTransform: 'uppercase',
   },
   caption: {
     fontFamily: fonts.main,
@@ -207,12 +202,13 @@ const typography = {
     lineHeight: '20px',
     fontStyle: 'italic',
   },
-  buttonSmall: {
-    fontFamily: fonts.secondary, // Chivo
+  overline: {
+    fontFamily: fonts.main,
     fontWeight: fontWeights.bold,
-    letterSpacing: letterSpacings.two, // 2px
     fontSize: '12px',
+    letterSpacing: letterSpacings.two, // 2px
     lineHeight: '16px',
+    textTransform: 'uppercase',
   },
   button: {
     fontFamily: fonts.secondary, // Chivo
@@ -221,32 +217,30 @@ const typography = {
     fontSize: '14px',
     lineHeight: '20px',
   },
+  // for buttons that are small
+  buttonSmall: {
+    fontFamily: fonts.secondary, // Chivo
+    fontWeight: fontWeights.bold,
+    letterSpacing: letterSpacings.two, // 2px
+    fontSize: '12px',
+    lineHeight: '16px',
+  },
   table: tableFormAlertStyle,
   forms: tableFormAlertStyle,
   alerts: tableFormAlertStyle,
   quote: {
     fontFamily: fonts.main,
     fontWeight: fontWeights.light,
-    fontSize: '28px',
+    fontSize: '22px',
     letterSpacing: letterSpacings.half, // 0.5px
-    lineHeight: '40px',
+    lineHeight: '33px',
   },
-  subtitle: {
-    fontFamily: fonts.main,
-    fontWeight: fontWeights.regular,
-    fontSize: '20px',
-    letterSpacing: letterSpacings.half, // 0.5px
-    lineHeight: '28px',
-  },
+
 };
 
 
 // styling specific to the Button component
 const buttons = {
-  font: fonts.secondary,
-  fontWeight: fontWeights.bold,
-  fontSize: '14px',
-  letterSpacing: '2px',
   sizingAndTypography: {
     small: {
       ...typography.buttonSmall,
@@ -346,10 +340,10 @@ const buttons = {
   secondary: {
     bg: {
       hover: bluePalette.darker,
-      disabled: greyPalette.light,
+      disabled: greyPalette.lighter,
     },
     fontColor: {
-      disabled: greyPalette.midtone,
+      disabled: greyPalette.light,
     },
     outline: {
       bg: {
@@ -357,10 +351,10 @@ const buttons = {
       },
       border: {
         hover: bluePalette.darker,
-        disabled: greyPalette.light,
+        disabled: greyPalette.lighter,
       },
       fontColor: {
-        disabled: indigoPalette.lighter,
+        disabled: greyPalette.lighter,
       },
     },
   },


### PR DESCRIPTION
Resolves #29 

- match colors (minor colors were changed - grey palette was made to match other palettes (no midtone and added new darker color))
- typography (removed hero, fixed sizing for quote + subtitle) - made the order it was defined to match design system spec lol
- removed scaling for letterSpacing  - #36 
- fixed Tag bug with styled system: styled-system `COLORS` uses bg, backgroundColor, and color props, which means it will override the prop `backgroundColor` passed into it. So i made the prop we generate from `variant` called `background` instead - its not necessarily a bug, but it may cause confusion (it did for buttons and made everything the `light` shade of the palette)

David, I will merge this in after yours.. cuz there will be merge conflicts
