### PR TITLE
Add Flex props to Box to allow it to be used as a flex item + bump to 0.0.4

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@hack4impact-uiuc/bridge",
-  "version": "0.0.3",
+  "version": "0.0.4",
   "description": "Hack4Impact UIUC's Design System + React Component library",
   "main": "dist/index.js",
   "author": "Timothy Ko <timothy.l.ko@gmail.com>",

--- a/src/__tests__/Box.js
+++ b/src/__tests__/Box.js
@@ -6,7 +6,7 @@ import '@testing-library/jest-dom';
 import { axe, toHaveNoViolations } from 'jest-axe';
 
 import { Box } from '..';
-import { COMMON, LAYOUT } from '../utils/constants';
+import { COMMON, LAYOUT, FLEX } from '../utils/constants';
 import theme from '../theme';
 import { renderJSON } from '../utils/testing';
 import 'babel-polyfill'; // axe violations required babel-polyfill
@@ -24,6 +24,7 @@ describe('Box', () => {
   it('implements system props', () => {
     expect(Box).toImplementSystemProps(LAYOUT);
     expect(Box).toImplementSystemProps(COMMON);
+    expect(Box).toImplementSystemProps(FLEX);
   });
 
   it('respects the "as" prop', () => {
@@ -51,5 +52,31 @@ describe('Box', () => {
     expect(renderJSON(<Box display="inline-block" />)).toMatchSnapshot();
     expect(renderJSON(<Box display="none" />)).toMatchSnapshot();
     expect(renderJSON(<Box display={['none', 'none', 'block']} theme={theme} />)).toMatchSnapshot();
+  });
+
+  // properties for children
+  // taken from https://css-tricks.com/snippets/css/a-guide-to-flexbox/
+  it('respects flex', () => {
+    expect(render(<Box flex="4 4" />)).toMatchSnapshot();
+  });
+
+  it('respects flexGrow', () => {
+    expect(render(<Box flexGrow="4" />)).toMatchSnapshot();
+  });
+
+  it('respects flexShrink', () => {
+    expect(render(<Box flexShrink="4" />)).toMatchSnapshot();
+  });
+
+  it('respects flexBasis', () => {
+    expect(render(<Box flexBasis="5rem" />)).toMatchSnapshot();
+  });
+
+  it('respects alignSelf', () => {
+    expect(render(<Box alignSelf="flex-start" />)).toMatchSnapshot();
+  });
+
+  it('respects order', () => {
+    expect(render(<Box order="5" />)).toMatchSnapshot();
   });
 });

--- a/src/__tests__/__snapshots__/Box.js.snap
+++ b/src/__tests__/__snapshots__/Box.js.snap
@@ -162,6 +162,81 @@ exports[`Box renders without any props 1`] = `
 />
 `;
 
+exports[`Box respects alignSelf 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  -webkit-align-self: flex-start;
+  -ms-flex-item-align: start;
+  align-self: flex-start;
+}
+
+<div>
+      <div
+        class="c0"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 THeBC"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
 exports[`Box respects display 1`] = `
 .c0 {
   display: inline;
@@ -222,4 +297,382 @@ exports[`Box respects display 4`] = `
     ]
   }
 />
+`;
+
+exports[`Box respects flex 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": .c0 {
+  -webkit-flex: 4 4;
+  -ms-flex: 4 4;
+  flex: 4 4;
+}
+
+<body>
+    <div>
+      <div
+        class="c0"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 etMsmz"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Box respects flexBasis 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  -webkit-flex-basis: 5rem;
+  -ms-flex-preferred-size: 5rem;
+  flex-basis: 5rem;
+}
+
+<div>
+      <div
+        class="c0"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 kGqbKb"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Box respects flexGrow 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  -webkit-box-flex: 4;
+  -webkit-flex-grow: 4;
+  -ms-flex-positive: 4;
+  flex-grow: 4;
+}
+
+<div>
+      <div
+        class="c0"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 cvhGzj"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Box respects flexShrink 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  -webkit-flex-shrink: 4;
+  -ms-flex-negative: 4;
+  flex-shrink: 4;
+}
+
+<div>
+      <div
+        class="c0"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 cnxAgD"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
+`;
+
+exports[`Box respects order 1`] = `
+Object {
+  "asFragment": [Function],
+  "baseElement": <body>
+    .c0 {
+  -webkit-order: 5;
+  -ms-flex-order: 5;
+  order: 5;
+}
+
+<div>
+      <div
+        class="c0"
+        order="5"
+      />
+    </div>
+  </body>,
+  "container": <div>
+    <div
+      class="Box-ik9o9h-0 bcDEBP"
+      order="5"
+    />
+  </div>,
+  "debug": [Function],
+  "findAllByAltText": [Function],
+  "findAllByDisplayValue": [Function],
+  "findAllByLabelText": [Function],
+  "findAllByPlaceholderText": [Function],
+  "findAllByRole": [Function],
+  "findAllByTestId": [Function],
+  "findAllByText": [Function],
+  "findAllByTitle": [Function],
+  "findByAltText": [Function],
+  "findByDisplayValue": [Function],
+  "findByLabelText": [Function],
+  "findByPlaceholderText": [Function],
+  "findByRole": [Function],
+  "findByTestId": [Function],
+  "findByText": [Function],
+  "findByTitle": [Function],
+  "getAllByAltText": [Function],
+  "getAllByDisplayValue": [Function],
+  "getAllByLabelText": [Function],
+  "getAllByPlaceholderText": [Function],
+  "getAllByRole": [Function],
+  "getAllByTestId": [Function],
+  "getAllByText": [Function],
+  "getAllByTitle": [Function],
+  "getByAltText": [Function],
+  "getByDisplayValue": [Function],
+  "getByLabelText": [Function],
+  "getByPlaceholderText": [Function],
+  "getByRole": [Function],
+  "getByTestId": [Function],
+  "getByText": [Function],
+  "getByTitle": [Function],
+  "queryAllByAltText": [Function],
+  "queryAllByDisplayValue": [Function],
+  "queryAllByLabelText": [Function],
+  "queryAllByPlaceholderText": [Function],
+  "queryAllByRole": [Function],
+  "queryAllByTestId": [Function],
+  "queryAllByText": [Function],
+  "queryAllByTitle": [Function],
+  "queryByAltText": [Function],
+  "queryByDisplayValue": [Function],
+  "queryByLabelText": [Function],
+  "queryByPlaceholderText": [Function],
+  "queryByRole": [Function],
+  "queryByTestId": [Function],
+  "queryByText": [Function],
+  "queryByTitle": [Function],
+  "rerender": [Function],
+  "unmount": [Function],
+}
 `;

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -3,11 +3,12 @@ import styled from 'styled-components';
 import PropTypes from 'prop-types';
 import { space, color } from 'styled-system';
 import systemPropTypes from '@styled-system/prop-types';
-import { LAYOUT } from '../../utils/constants';
+import { LAYOUT, FLEX } from '../../utils/constants';
 import theme from '../../theme';
 
 const Box = styled.div`
   ${LAYOUT}
+  ${FLEX}
   ${space}
   ${color}
 `;
@@ -16,6 +17,7 @@ Box.defaultProps = { theme };
 
 Box.propTypes = {
   ...LAYOUT.propTypes,
+  ...FLEX.propTypes,
   ...systemPropTypes.space,
   ...systemPropTypes.color,
   theme: PropTypes.object,

--- a/src/components/Box/Box.js
+++ b/src/components/Box/Box.js
@@ -1,25 +1,21 @@
 // taken from Github primer/components https://github.com/primer/components/blob/master/src/Box.js
 import styled from 'styled-components';
 import PropTypes from 'prop-types';
-import { space, color } from 'styled-system';
-import systemPropTypes from '@styled-system/prop-types';
-import { LAYOUT, FLEX } from '../../utils/constants';
+import { COMMON, FLEX, COLOR } from '../../utils/constants';
 import theme from '../../theme';
 
 const Box = styled.div`
-  ${LAYOUT}
-  ${FLEX}
-  ${space}
-  ${color}
+  ${COMMON};
+  ${FLEX};
+  ${COLOR};
 `;
 
 Box.defaultProps = { theme };
 
 Box.propTypes = {
-  ...LAYOUT.propTypes,
+  ...COMMON.propTypes,
   ...FLEX.propTypes,
-  ...systemPropTypes.space,
-  ...systemPropTypes.color,
+  ...COLOR.propTypes,
   theme: PropTypes.object,
 };
 

--- a/src/components/Flex/Flex.js
+++ b/src/components/Flex/Flex.js
@@ -1,11 +1,8 @@
 import styled from 'styled-components';
-import { FLEX } from '../../utils/constants';
 import theme from '../../theme';
 import Box from '../Box';
 
-const Flex = styled(Box)`
-  ${FLEX};
-`;
+const Flex = styled(Box)``;
 
 Flex.defaultProps = {
   theme,
@@ -14,7 +11,6 @@ Flex.defaultProps = {
 
 Flex.propTypes = {
   ...Box.propTypes,
-  ...FLEX.propTypes,
 };
 
 export default Flex;


### PR DESCRIPTION
will merge after #48 

we need a container for Flexbox items
`<Flex>` currently sets display as `flex`

but Flexbox items don't need that. We can use `<Box>` for that 