### PR TITLE
fix bug where button size gets bigger because of outline

### DIFF
--- a/src/__tests__/__snapshots__/Button.js.snap
+++ b/src/__tests__/__snapshots__/Button.js.snap
@@ -14,18 +14,18 @@ exports[`Button Colors renders error colors 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #A62B31;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #8A1A1F;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -33,7 +33,7 @@ exports[`Button Colors renders error colors 1`] = `
 
 .c0:disabled {
   background: #FFBCBF;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #D1595F;
 }
@@ -58,18 +58,18 @@ exports[`Button Colors renders primary colors 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -77,7 +77,7 @@ exports[`Button Colors renders primary colors 1`] = `
 
 .c0:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }
@@ -102,18 +102,18 @@ exports[`Button Colors renders secondary colors 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0D3F6E;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -121,7 +121,7 @@ exports[`Button Colors renders secondary colors 1`] = `
 
 .c0:disabled {
   background: #EBEEF2;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #8B9199;
 }
@@ -146,18 +146,18 @@ exports[`Button Colors renders success colors 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #4C9859;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #256830;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -165,7 +165,7 @@ exports[`Button Colors renders success colors 1`] = `
 
 .c0:disabled {
   background: #BDF3C6;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #90E19E;
 }
@@ -190,18 +190,18 @@ exports[`Button Colors renders warning colors 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #FDBE21;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #DA9C03;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -209,7 +209,7 @@ exports[`Button Colors renders warning colors 1`] = `
 
 .c0:disabled {
   background: #FFECBD;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFD15F;
 }
@@ -234,18 +234,18 @@ exports[`Button Sizes renders a large button 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 14px 32px;
+  padding: 12px 30px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -253,7 +253,7 @@ exports[`Button Sizes renders a large button 1`] = `
 
 .c0:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }
@@ -278,18 +278,18 @@ exports[`Button Sizes renders a medium button 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -297,7 +297,7 @@ exports[`Button Sizes renders a medium button 1`] = `
 
 .c0:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }
@@ -322,18 +322,18 @@ exports[`Button Sizes renders a small button 1`] = `
   letter-spacing: 2px;
   font-size: 12px;
   line-height: 16px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -341,7 +341,7 @@ exports[`Button Sizes renders a small button 1`] = `
 
 .c0:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }
@@ -366,7 +366,7 @@ exports[`Button renders correct colors with "outline" and "disabled" props (prim
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
@@ -411,7 +411,7 @@ exports[`Button respects "outline" prop 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
@@ -455,18 +455,18 @@ exports[`Button respects the "disabled" prop 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c0:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -474,7 +474,7 @@ exports[`Button respects the "disabled" prop 1`] = `
 
 .c0:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }

--- a/src/__tests__/__snapshots__/Card.js.snap
+++ b/src/__tests__/__snapshots__/Card.js.snap
@@ -33,18 +33,18 @@ exports[`Card renders entire card properly 1`] = `
   letter-spacing: 2px;
   font-size: 14px;
   line-height: 20px;
-  padding: 12px 16px;
+  padding: 10px 14px;
   display: inline-block;
   text-align: center;
   vertical-align: middle;
   background: #155DA1;
-  border: none;
+  border: 2px solid transparent;
   color: #FFFFFF;
 }
 
 .c8:hover:not([disabled]) {
   background: #0E4E8A;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
   cursor: pointer;
@@ -52,7 +52,7 @@ exports[`Card renders entire card properly 1`] = `
 
 .c8:disabled {
   background: #B4D8FA;
-  border: none;
+  border: 2px solid transparent;
   box-shadow: none;
   color: #FFFFFF;
 }

--- a/src/components/Button/Button.js
+++ b/src/components/Button/Button.js
@@ -67,9 +67,9 @@ const Button = ({
   };
 
   let border = {
-    default: lodashGet(buttonTheme, 'border.default', buttonDefaultTheme.border.default),
-    hover: lodashGet(buttonTheme, 'border.hover', buttonDefaultTheme.border.hover),
-    disabled: lodashGet(buttonTheme, 'border.disabled', buttonDefaultTheme.border.disabled),
+    default: `2px solid ${lodashGet(buttonTheme, 'border.default', buttonDefaultTheme.border.default)}`,
+    hover: `2px solid ${lodashGet(buttonTheme, 'border.hover', buttonDefaultTheme.border.hover)}`,
+    disabled: `2px solid ${lodashGet(buttonTheme, 'border.disabled', buttonDefaultTheme.border.disabled)}`,
   };
 
   let fontColor = {

--- a/src/theme.js
+++ b/src/theme.js
@@ -241,18 +241,20 @@ const typography = {
 
 // styling specific to the Button component
 const buttons = {
+  // padding is 2px smaller than defined in design system
+  // because of 2px border
   sizingAndTypography: {
     small: {
       ...typography.buttonSmall,
-      padding: '12px 16px',
+      padding: '10px 14px',
     },
     medium: {
       ...typography.button,
-      padding: '12px 16px',
+      padding: '10px 14px',
     },
     large: {
       ...typography.button,
-      padding: '14px 32px',
+      padding: '12px 30px',
     },
   },
   // default values, based on the color palette
@@ -263,9 +265,9 @@ const buttons = {
       disabled: colorPalette.lighter,
     },
     border: {
-      default: 'none',
-      hover: 'none',
-      disabled: 'none',
+      default: 'transparent',
+      hover: 'transparent',
+      disabled: 'transparent',
     },
     fontColor: {
       default: colors.white,


### PR DESCRIPTION
button with outline prop resizes 4px larger because of border width of 2px - instead I made the padding 2px smaller and have the border 2px - when it's not `outline` border is transparent. 