### PR TITLE
Table font, Card default size, grey vs gray fixes

### DIFF
--- a/docs/components/design/colorPalette.js
+++ b/docs/components/design/colorPalette.js
@@ -18,7 +18,7 @@ const PaletteShade = ({ palette, name }) => (
       color = palette.text;
     }
     if (label === 'white') {
-      color = theme.colors.text.greyScale.main;
+      color = theme.colors.text.grayScale.main;
       borderStyling = WhiteBorderStyling;
     }
     if (label === 'primary') {

--- a/docs/components/design/colorPalette.js
+++ b/docs/components/design/colorPalette.js
@@ -1,5 +1,5 @@
 import {
-  theme, Flex, Box, Text, Heading,
+  theme, Flex, Box, Text,
 } from '@hack4impact-uiuc/bridge';
 
 const WhiteBorderStyling = {
@@ -18,7 +18,7 @@ const PaletteShade = ({ palette, name }) => (
       color = palette.text;
     }
     if (label === 'white') {
-      color = theme.colors.text.grayScale.main;
+      color = theme.colors.text.greyScale.main;
       borderStyling = WhiteBorderStyling;
     }
     if (label === 'primary') {

--- a/docs/pages/design/colors.mdx
+++ b/docs/pages/design/colors.mdx
@@ -23,7 +23,7 @@ Secondary colors are for actions or states. Green is for success. Red is for err
 Top color indicates a color that can be used for main text.
 Bottom color is used for supporting text.
 
-<ColorPalette palettes={[{name: "Charcoal", palette: {"Charcoal": theme.colors.text.grayScale.main, "Iron": theme.colors.text.grayScale.support}}, {name: "Cool Tone", palette: { "Ink": theme.colors.text.coolTone.main, "Slate": theme.colors.text.coolTone.support}}, {name: "White", palette: {white: "#FFFFFF" }}]} />
+<ColorPalette palettes={[{name: "Charcoal", palette: {"Charcoal": theme.colors.text.greyScale.main, "Iron": theme.colors.text.greyScale.support}}, {name: "Cool Tone", palette: { "Ink": theme.colors.text.coolTone.main, "Slate": theme.colors.text.coolTone.support}}, {name: "White", palette: {white: "#FFFFFF" }}]} />
 
 #### Usage
 

--- a/docs/pages/design/colors.mdx
+++ b/docs/pages/design/colors.mdx
@@ -23,7 +23,7 @@ Secondary colors are for actions or states. Green is for success. Red is for err
 Top color indicates a color that can be used for main text.
 Bottom color is used for supporting text.
 
-<ColorPalette palettes={[{name: "Charcoal", palette: {"Charcoal": theme.colors.text.greyScale.main, "Iron": theme.colors.text.greyScale.support}}, {name: "Cool Tone", palette: { "Ink": theme.colors.text.coolTone.main, "Slate": theme.colors.text.coolTone.support}}, {name: "White", palette: {white: "#FFFFFF" }}]} />
+<ColorPalette palettes={[{name: "Charcoal", palette: {"Charcoal": theme.colors.text.grayScale.main, "Iron": theme.colors.text.grayScale.support}}, {name: "Cool Tone", palette: { "Ink": theme.colors.text.coolTone.main, "Slate": theme.colors.text.coolTone.support}}, {name: "White", palette: {white: "#FFFFFF" }}]} />
 
 #### Usage
 

--- a/playground/Playground.js
+++ b/playground/Playground.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { colors } from '../src/theme';
 
 import {
-  Button, Card, Heading, Link, Text, Icon, TextField,
+  Button, Card, Heading, Link, Text, Icon, TextField, Table,
 } from '../src';
 
 const {
@@ -12,11 +12,44 @@ const {
 // import any components here
 
 export function Playground() {
+  const {
+    Head, Body, Row, Cell,
+  } = Table;
+
   return (
     <>
       <div>
         {/* Add the code you want to test here */}
-        <Button variant="primary">APPLY</Button>
+        <Table type="zebra">
+          <Head>
+            <Row>
+              <Cell>First Name</Cell>
+              <Cell>Last Name</Cell>
+              <Cell>Favorite Color</Cell>
+              <Cell>Favorite Number</Cell>
+            </Row>
+          </Head>
+          <Body>
+            <Row fontSize="18px">
+              <Cell fontSize="12px">Chloe</Cell>
+              <Cell fontSize="12px">Chan</Cell>
+              <Cell>Pink</Cell>
+              <Cell>3</Cell>
+            </Row>
+            <Row>
+              <Cell>Ashley</Cell>
+              <Cell>Chan</Cell>
+              <Cell>Blue</Cell>
+              <Cell>7</Cell>
+            </Row>
+            <Row>
+              <Cell>Nicole</Cell>
+              <Cell>Nguyen</Cell>
+              <Cell>Red</Cell>
+              <Cell>10</Cell>
+            </Row>
+          </Body>
+        </Table>
       </div>
     </>
   );

--- a/playground/Playground.js
+++ b/playground/Playground.js
@@ -3,7 +3,7 @@ import React from 'react';
 import { colors } from '../src/theme';
 
 import {
-  Button, Card, Heading, Link, Text, Icon, TextField, Table,
+  Button, Card, Heading, Link, Text, Icon,
 } from '../src';
 
 const {
@@ -12,44 +12,11 @@ const {
 // import any components here
 
 export function Playground() {
-  const {
-    Head, Body, Row, Cell,
-  } = Table;
-
   return (
     <>
       <div>
         {/* Add the code you want to test here */}
-        <Table type="zebra">
-          <Head>
-            <Row>
-              <Cell>First Name</Cell>
-              <Cell>Last Name</Cell>
-              <Cell>Favorite Color</Cell>
-              <Cell>Favorite Number</Cell>
-            </Row>
-          </Head>
-          <Body>
-            <Row fontSize="18px">
-              <Cell fontSize="12px">Chloe</Cell>
-              <Cell fontSize="12px">Chan</Cell>
-              <Cell>Pink</Cell>
-              <Cell>3</Cell>
-            </Row>
-            <Row>
-              <Cell>Ashley</Cell>
-              <Cell>Chan</Cell>
-              <Cell>Blue</Cell>
-              <Cell>7</Cell>
-            </Row>
-            <Row>
-              <Cell>Nicole</Cell>
-              <Cell>Nguyen</Cell>
-              <Cell>Red</Cell>
-              <Cell>10</Cell>
-            </Row>
-          </Body>
-        </Table>
+        <Button variant="primary">APPLY</Button>
       </div>
     </>
   );

--- a/src/__tests__/Table.js
+++ b/src/__tests__/Table.js
@@ -131,7 +131,7 @@ describe('Table', () => {
       </Table>,
     );
 
-    const head = container.firstChild.firstChild;
+    const head = container.firstChild.firstChild.firstChild.firstChild;
     expect(head).toHaveStyle(`font-weight: ${theme.typography.tableHead.fontWeight}px`);
   });
 

--- a/src/__tests__/Table.js
+++ b/src/__tests__/Table.js
@@ -131,8 +131,8 @@ describe('Table', () => {
       </Table>,
     );
 
-    const headCell = container.firstChild.firstChild.firstChild.firstChild;
-    expect(headCell).toHaveStyle(`font-weight: ${theme.typography.tableHead.fontWeight}px`);
+    const head = container.firstChild.firstChild;
+    expect(head).toHaveStyle(`font-weight: ${theme.typography.tableHead.fontWeight}px`);
   });
 
   it('uses table body typography from theme', () => {
@@ -142,7 +142,7 @@ describe('Table', () => {
       </Table>,
     );
 
-    const bodyCell = container.firstChild.firstChild.firstChild.firstChild;
+    const bodyCell = container.firstChild.firstChild;
     expect(bodyCell).toHaveStyle(`font-weight: ${theme.typography.table.fontWeight}px`);
     expect(bodyCell).toHaveStyle(`font-size: ${theme.typography.table.fontSize}`);
     expect(bodyCell).toHaveStyle(`line-height: ${theme.typography.table.lineHeight}`);

--- a/src/__tests__/__snapshots__/Card.js.snap
+++ b/src/__tests__/__snapshots__/Card.js.snap
@@ -4,7 +4,7 @@ exports[`Card renders a <div> 1`] = `
 .c0 {
   display: inline-block;
   vertical-align: top;
-  width: 471px;
+  width: 318px;
   background-color: #FFFFFF;
   border-radius: 8px;
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.24);
@@ -125,7 +125,7 @@ exports[`Card renders entire card properly 1`] = `
 .c0 {
   display: inline-block;
   vertical-align: top;
-  width: 471px;
+  width: 318px;
   background-color: #FFFFFF;
   border-radius: 8px;
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.24);

--- a/src/__tests__/__snapshots__/Table.js.snap
+++ b/src/__tests__/__snapshots__/Table.js.snap
@@ -8,29 +8,6 @@ exports[`Table renders a <table> 1`] = `
   width: 100%;
 }
 
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-  font-weight: 500px;
-}
-
 .c0 .TableHead__TableHeadBase-sc-154km0i-0 .TableRow__TableRowBase-sc-1npg197-0 {
   border-bottom: 1px solid #EBEEF2;
   border-width: 2px;
@@ -54,41 +31,19 @@ exports[`Table renders borderless bodyless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
-  height: 56px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -100,11 +55,22 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-width: 2px;
 }
 
-.c0 .TableBody-lzp76z-0 .c2:last-child {
+.c0 .TableBody-lzp76z-0 .c3:last-child {
   border-bottom: none;
 }
 
@@ -114,28 +80,28 @@ Object {
         type="borderless"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
@@ -146,11 +112,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 eeyPOb"
+      class="Table-sc-1399pyx-0 iCcwbF"
       type="borderless"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -238,45 +204,6 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c7 {
-  padding: 0 20px;
-}
-
-.c7:first-child {
-  padding-left: 0;
-}
-
-.c7:last-child {
-  padding-right: 0;
-}
-
-.c4 {
-  padding: 0 20px;
-}
-
-.c4:first-child {
-  padding-left: 0;
-}
-
-.c4:last-child {
-  padding-right: 0;
-}
-
-.c3 {
-  height: 56px;
-}
-
-.c6 {
-  height: 52px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -287,7 +214,31 @@ Object {
   line-height: 20px;
 }
 
-.c0 th {
+.c9 {
+  padding: 0 20px;
+}
+
+.c9:first-child {
+  padding-left: 0;
+}
+
+.c9:last-child {
+  padding-right: 0;
+}
+
+.c5 {
+  padding: 0 20px;
+}
+
+.c5:first-child {
+  padding-left: 0;
+}
+
+.c5:last-child {
+  padding-right: 0;
+}
+
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -299,11 +250,26 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c8 {
+  height: 52px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-width: 2px;
 }
 
-.c0 .c5 .c2:last-child {
+.c0 .c6 .c3:last-child {
   border-bottom: none;
 }
 
@@ -313,104 +279,104 @@ Object {
         type="borderless"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
           </tr>
         </thead>
         <tbody
-          class="c5 "
+          class="c6 c7"
         >
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Chloe
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Chan
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Pink
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Eric
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Lee
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Blue
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Nicole
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Nguyen
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Red
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               10
             </td>
@@ -421,11 +387,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 eeyPOb"
+      class="Table-sc-1399pyx-0 iCcwbF"
       type="borderless"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -453,7 +419,7 @@ Object {
         </tr>
       </thead>
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"
@@ -588,19 +554,30 @@ exports[`Table renders borderless headless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c2 {
+  font-family: HKGrotesk;
+  font-weight: 400px;
+  font-size: 18px;
+  -webkit-letter-spacing: 0.3px;
+  -moz-letter-spacing: 0.3px;
+  -ms-letter-spacing: 0.3px;
+  letter-spacing: 0.3px;
+  line-height: 20px;
+}
+
+.c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
+.c4 {
   height: 52px;
 }
 
@@ -611,34 +588,11 @@ Object {
   width: 100%;
 }
 
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-  font-weight: 500px;
-}
-
-.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c2 {
+.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c3 {
   border-width: 2px;
 }
 
-.c0 .c1 .c2:last-child {
+.c0 .c1 .c3:last-child {
   border-bottom: none;
 }
 
@@ -648,76 +602,76 @@ Object {
         type="borderless"
       >
         <tbody
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Chloe
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Chan
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Pink
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Eric
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Lee
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Blue
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Nicole
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Nguyen
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Red
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               10
             </td>
@@ -728,11 +682,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 eeyPOb"
+      class="Table-sc-1399pyx-0 iCcwbF"
       type="borderless"
     >
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"
@@ -867,41 +821,19 @@ exports[`Table renders primary bodyless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
-  height: 56px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -913,16 +845,27 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-bottom: 1px solid #EBEEF2;
   border-width: 2px;
 }
 
-.c0 .TableBody-lzp76z-0 .c2 {
+.c0 .TableBody-lzp76z-0 .c3 {
   border-bottom: 1px solid #EBEEF2;
 }
 
-.c0 .TableBody-lzp76z-0 .c2:last-child {
+.c0 .TableBody-lzp76z-0 .c3:last-child {
   border-bottom: none;
 }
 
@@ -932,28 +875,28 @@ Object {
         type="primary"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
@@ -964,11 +907,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 ebRcbD"
+      class="Table-sc-1399pyx-0 eWlCfV"
       type="primary"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -1055,45 +998,6 @@ exports[`Table renders primary full table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": .c7 {
-  padding: 0 20px;
-}
-
-.c7:first-child {
-  padding-left: 0;
-}
-
-.c7:last-child {
-  padding-right: 0;
-}
-
-.c4 {
-  padding: 0 20px;
-}
-
-.c4:first-child {
-  padding-left: 0;
-}
-
-.c4:last-child {
-  padding-right: 0;
-}
-
-.c3 {
-  height: 56px;
-}
-
-.c6 {
-  height: 52px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -1104,7 +1008,31 @@ Object {
   line-height: 20px;
 }
 
-.c0 th {
+.c9 {
+  padding: 0 20px;
+}
+
+.c9:first-child {
+  padding-left: 0;
+}
+
+.c9:last-child {
+  padding-right: 0;
+}
+
+.c5 {
+  padding: 0 20px;
+}
+
+.c5:first-child {
+  padding-left: 0;
+}
+
+.c5:last-child {
+  padding-right: 0;
+}
+
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -1116,16 +1044,31 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c8 {
+  height: 52px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-bottom: 1px solid #EBEEF2;
   border-width: 2px;
 }
 
-.c0 .c5 .c2 {
+.c0 .c6 .c3 {
   border-bottom: 1px solid #EBEEF2;
 }
 
-.c0 .c5 .c2:last-child {
+.c0 .c6 .c3:last-child {
   border-bottom: none;
 }
 
@@ -1136,104 +1079,104 @@ Object {
         type="primary"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
           </tr>
         </thead>
         <tbody
-          class="c5 "
+          class="c6 c7"
         >
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Chloe
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Chan
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Pink
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Eric
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Lee
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Blue
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Nicole
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Nguyen
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Red
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               10
             </td>
@@ -1244,11 +1187,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 ebRcbD"
+      class="Table-sc-1399pyx-0 eWlCfV"
       type="primary"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -1276,7 +1219,7 @@ Object {
         </tr>
       </thead>
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"
@@ -1411,19 +1354,30 @@ exports[`Table renders primary headless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c2 {
+  font-family: HKGrotesk;
+  font-weight: 400px;
+  font-size: 18px;
+  -webkit-letter-spacing: 0.3px;
+  -moz-letter-spacing: 0.3px;
+  -ms-letter-spacing: 0.3px;
+  letter-spacing: 0.3px;
+  line-height: 20px;
+}
+
+.c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
+.c4 {
   height: 52px;
 }
 
@@ -1434,39 +1388,16 @@ Object {
   width: 100%;
 }
 
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-  font-weight: 500px;
-}
-
-.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c2 {
+.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c3 {
   border-bottom: 1px solid #EBEEF2;
   border-width: 2px;
 }
 
-.c0 .c1 .c2 {
+.c0 .c1 .c3 {
   border-bottom: 1px solid #EBEEF2;
 }
 
-.c0 .c1 .c2:last-child {
+.c0 .c1 .c3:last-child {
   border-bottom: none;
 }
 
@@ -1476,76 +1407,76 @@ Object {
         type="primary"
       >
         <tbody
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Chloe
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Chan
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Pink
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Eric
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Lee
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Blue
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Nicole
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Nguyen
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Red
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               10
             </td>
@@ -1556,11 +1487,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 ebRcbD"
+      class="Table-sc-1399pyx-0 eWlCfV"
       type="primary"
     >
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"
@@ -1695,41 +1626,19 @@ exports[`Table renders zebra bodyless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
-  height: 56px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -1741,15 +1650,26 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-width: 2px;
 }
 
-.c0 .TableBody-lzp76z-0 .c2:nth-child(odd) {
+.c0 .TableBody-lzp76z-0 .c3:nth-child(odd) {
   background-color: #EBEEF2;
 }
 
-.c0 .TableBody-lzp76z-0 .c2:last-child {
+.c0 .TableBody-lzp76z-0 .c3:last-child {
   border-bottom: none;
 }
 
@@ -1759,28 +1679,28 @@ Object {
         type="zebra"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
@@ -1791,11 +1711,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 jjNDbD"
+      class="Table-sc-1399pyx-0 iyjCWd"
       type="zebra"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -1883,45 +1803,6 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c7 {
-  padding: 0 20px;
-}
-
-.c7:first-child {
-  padding-left: 0;
-}
-
-.c7:last-child {
-  padding-right: 0;
-}
-
-.c4 {
-  padding: 0 20px;
-}
-
-.c4:first-child {
-  padding-left: 0;
-}
-
-.c4:last-child {
-  padding-right: 0;
-}
-
-.c3 {
-  height: 56px;
-}
-
-.c6 {
-  height: 52px;
-}
-
-.c0 {
-  background-color: #FFFFFF;
-  text-align: center;
-  border-collapse: collapse;
-  width: 100%;
-}
-
-.c0 td {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -1932,7 +1813,31 @@ Object {
   line-height: 20px;
 }
 
-.c0 th {
+.c9 {
+  padding: 0 20px;
+}
+
+.c9:first-child {
+  padding-left: 0;
+}
+
+.c9:last-child {
+  padding-right: 0;
+}
+
+.c5 {
+  padding: 0 20px;
+}
+
+.c5:first-child {
+  padding-left: 0;
+}
+
+.c5:last-child {
+  padding-right: 0;
+}
+
+.c2 {
   font-family: HKGrotesk;
   font-weight: 400px;
   font-size: 18px;
@@ -1944,15 +1849,30 @@ Object {
   font-weight: 500px;
 }
 
-.c0 .c1 .c2 {
+.c4 {
+  height: 56px;
+}
+
+.c8 {
+  height: 52px;
+}
+
+.c0 {
+  background-color: #FFFFFF;
+  text-align: center;
+  border-collapse: collapse;
+  width: 100%;
+}
+
+.c0 .c1 .c3 {
   border-width: 2px;
 }
 
-.c0 .c5 .c2:nth-child(odd) {
+.c0 .c6 .c3:nth-child(odd) {
   background-color: #EBEEF2;
 }
 
-.c0 .c5 .c2:last-child {
+.c0 .c6 .c3:last-child {
   border-bottom: none;
 }
 
@@ -1962,104 +1882,104 @@ Object {
         type="zebra"
       >
         <thead
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <th
-              class="c4"
+              class="c5"
             >
               First Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Last Name
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Color
             </th>
             <th
-              class="c4"
+              class="c5"
             >
               Favorite Number
             </th>
           </tr>
         </thead>
         <tbody
-          class="c5 "
+          class="c6 c7"
         >
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Chloe
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Chan
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Pink
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Eric
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Lee
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Blue
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c6"
+            class="c3 c8"
           >
             <td
-              class="c7"
+              class="c9"
             >
               Nicole
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Nguyen
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               Red
             </td>
             <td
-              class="c7"
+              class="c9"
             >
               10
             </td>
@@ -2070,11 +1990,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 jjNDbD"
+      class="Table-sc-1399pyx-0 iyjCWd"
       type="zebra"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 cbcdZM"
+        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
@@ -2102,7 +2022,7 @@ Object {
         </tr>
       </thead>
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"
@@ -2237,19 +2157,30 @@ exports[`Table renders zebra headless table successfully 1`] = `
 Object {
   "asFragment": [Function],
   "baseElement": <body>
-    .c4 {
+    .c2 {
+  font-family: HKGrotesk;
+  font-weight: 400px;
+  font-size: 18px;
+  -webkit-letter-spacing: 0.3px;
+  -moz-letter-spacing: 0.3px;
+  -ms-letter-spacing: 0.3px;
+  letter-spacing: 0.3px;
+  line-height: 20px;
+}
+
+.c5 {
   padding: 0 20px;
 }
 
-.c4:first-child {
+.c5:first-child {
   padding-left: 0;
 }
 
-.c4:last-child {
+.c5:last-child {
   padding-right: 0;
 }
 
-.c3 {
+.c4 {
   height: 52px;
 }
 
@@ -2260,38 +2191,15 @@ Object {
   width: 100%;
 }
 
-.c0 td {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-}
-
-.c0 th {
-  font-family: HKGrotesk;
-  font-weight: 400px;
-  font-size: 18px;
-  -webkit-letter-spacing: 0.3px;
-  -moz-letter-spacing: 0.3px;
-  -ms-letter-spacing: 0.3px;
-  letter-spacing: 0.3px;
-  line-height: 20px;
-  font-weight: 500px;
-}
-
-.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c2 {
+.c0 .TableHead__TableHeadBase-sc-154km0i-0 .c3 {
   border-width: 2px;
 }
 
-.c0 .c1 .c2:nth-child(odd) {
+.c0 .c1 .c3:nth-child(odd) {
   background-color: #EBEEF2;
 }
 
-.c0 .c1 .c2:last-child {
+.c0 .c1 .c3:last-child {
   border-bottom: none;
 }
 
@@ -2301,76 +2209,76 @@ Object {
         type="zebra"
       >
         <tbody
-          class="c1 "
+          class="c1 c2"
         >
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Chloe
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Chan
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Pink
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               3
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Eric
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Lee
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Blue
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               18
             </td>
           </tr>
           <tr
-            class="c2 c3"
+            class="c3 c4"
           >
             <td
-              class="c4"
+              class="c5"
             >
               Nicole
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Nguyen
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               Red
             </td>
             <td
-              class="c4"
+              class="c5"
             >
               10
             </td>
@@ -2381,11 +2289,11 @@ Object {
   </body>,
   "container": <div>
     <table
-      class="Table-sc-1399pyx-0 jjNDbD"
+      class="Table-sc-1399pyx-0 iyjCWd"
       type="zebra"
     >
       <tbody
-        class="TableBody-lzp76z-0 jDkdhk"
+        class="TableBody-lzp76z-0 dTozHy"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 EQrRR"

--- a/src/__tests__/__snapshots__/Table.js.snap
+++ b/src/__tests__/__snapshots__/Table.js.snap
@@ -32,6 +32,7 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -52,7 +53,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -116,28 +116,28 @@ Object {
       type="borderless"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>
@@ -227,6 +227,7 @@ Object {
 }
 
 .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -247,7 +248,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -391,28 +391,28 @@ Object {
       type="borderless"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>
@@ -822,6 +822,7 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -842,7 +843,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -911,28 +911,28 @@ Object {
       type="primary"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>
@@ -1021,6 +1021,7 @@ Object {
 }
 
 .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -1041,7 +1042,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -1191,28 +1191,28 @@ Object {
       type="primary"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>
@@ -1627,6 +1627,7 @@ Object {
   "asFragment": [Function],
   "baseElement": <body>
     .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -1647,7 +1648,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -1715,28 +1715,28 @@ Object {
       type="zebra"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>
@@ -1826,6 +1826,7 @@ Object {
 }
 
 .c5 {
+  font-weight: 500px;
   padding: 0 20px;
 }
 
@@ -1846,7 +1847,6 @@ Object {
   -ms-letter-spacing: 0.3px;
   letter-spacing: 0.3px;
   line-height: 20px;
-  font-weight: 500px;
 }
 
 .c4 {
@@ -1994,28 +1994,28 @@ Object {
       type="zebra"
     >
       <thead
-        class="TableHead__TableHeadBase-sc-154km0i-0 frVrMO"
+        class="TableHead__TableHeadBase-sc-154km0i-0 egHoGZ"
       >
         <tr
           class="TableRow__TableRowBase-sc-1npg197-0 hezjzp"
         >
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             First Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Last Name
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Color
           </th>
           <th
-            class="TableCell__TableHeadCellBase-sc-18perrz-1 dDqyXv"
+            class="TableCell__TableHeadCellBase-sc-18perrz-1 hOwtmk"
           >
             Favorite Number
           </th>

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -16,7 +16,7 @@ const Card = styled.div`
   display: inline-block;
   vertical-align: top;
 
-  width: 471px;
+  width: 318px;
 
   background-color: ${get('colors.white')};
   border-radius: 8px;

--- a/src/components/Table/Table.js
+++ b/src/components/Table/Table.js
@@ -16,15 +16,6 @@ const Table = styled.table`
     border-collapse: collapse;
     width: 100%;
     
-    & td {
-      ${get('typography.table')};
-    }
-
-    & th {
-      ${get('typography.table')};
-      ${get('typography.tableHead')}
-    }
-
     ${TableHeadBase} ${TableRowBase} {
       border-bottom: ${(props) => props.type === 'primary' && `${get('table.primary.borderBottom')(props)}`};
       border-width: 2px;

--- a/src/components/Table/TableBody.js
+++ b/src/components/Table/TableBody.js
@@ -1,11 +1,15 @@
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import theme from '../../theme';
+import { get } from '../../utils/utils';
 import { COMMON, TYPOGRAPHY } from '../../utils/constants';
 
 const TableBody = styled.tbody`
-    ${COMMON};
-    ${TYPOGRAPHY};
+
+  ${get('typography.table')};
+
+  ${COMMON};
+  ${TYPOGRAPHY};
 `;
 
 TableBody.defaultProps = { theme };

--- a/src/components/Table/TableCell.js
+++ b/src/components/Table/TableCell.js
@@ -2,7 +2,6 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import React from 'react';
 import theme from '../../theme';
-import { get } from '../../utils/utils';
 import { COMMON, TYPOGRAPHY } from '../../utils/constants';
 import TableHeadContext from './TableHeadContext';
 

--- a/src/components/Table/TableCell.js
+++ b/src/components/Table/TableCell.js
@@ -2,31 +2,32 @@ import PropTypes from 'prop-types';
 import styled, { css } from 'styled-components';
 import React from 'react';
 import theme from '../../theme';
+import { get } from '../../utils/utils';
 import { COMMON, TYPOGRAPHY } from '../../utils/constants';
 import TableHeadContext from './TableHeadContext';
 
 
 const sharedStyle = css`
-    padding: 0 20px;
-    &:first-child {
-        padding-left: 0;
-    }
 
-    &:last-child {
-        padding-right: 0;
-    }
+  padding: 0 20px;
+  &:first-child {
+      padding-left: 0;
+  }
 
+  &:last-child {
+      padding-right: 0;
+  }
 
-    ${COMMON};
-    ${TYPOGRAPHY};
+  ${COMMON};
+  ${TYPOGRAPHY};
 `;
 
 const TableCellBase = styled.td`
-    ${sharedStyle};
+  ${sharedStyle};
 `;
 
 const TableHeadCellBase = styled.th`
-    ${sharedStyle};
+  ${sharedStyle};
 `;
 
 const TableCell = ({ children, ...props }) => {

--- a/src/components/Table/TableCell.js
+++ b/src/components/Table/TableCell.js
@@ -3,6 +3,7 @@ import styled, { css } from 'styled-components';
 import React from 'react';
 import theme from '../../theme';
 import { COMMON, TYPOGRAPHY } from '../../utils/constants';
+import { get } from '../../utils/utils';
 import TableHeadContext from './TableHeadContext';
 
 
@@ -26,6 +27,7 @@ const TableCellBase = styled.td`
 `;
 
 const TableHeadCellBase = styled.th`
+  ${get('typography.tableHead')}
   ${sharedStyle};
 `;
 

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -2,6 +2,7 @@ import PropTypes from 'prop-types';
 import styled from 'styled-components';
 import React from 'react';
 import theme from '../../theme';
+import { get } from '../../utils/utils';
 import { COMMON, TYPOGRAPHY } from '../../utils/constants';
 import TableHeadContext from './TableHeadContext';
 
@@ -11,8 +12,11 @@ const context = {
 };
 
 export const TableHeadBase = styled.thead`
-    ${COMMON};
-    ${TYPOGRAPHY};
+  ${get('typography.table')}
+  ${get('typography.tableHead')}
+  
+  ${COMMON};
+  ${TYPOGRAPHY};
 `;
 
 const TableHead = ({ children, ...props }) => (

--- a/src/components/Table/TableHead.js
+++ b/src/components/Table/TableHead.js
@@ -13,7 +13,6 @@ const context = {
 
 export const TableHeadBase = styled.thead`
   ${get('typography.table')}
-  ${get('typography.tableHead')}
   
   ${COMMON};
   ${TYPOGRAPHY};

--- a/src/components/Table/TableRow.js
+++ b/src/components/Table/TableRow.js
@@ -7,10 +7,10 @@ import TableHeadContext from './TableHeadContext';
 
 
 export const TableRowBase = styled.tr`
-    height: ${(props) => (props.isHeadRow ? '56px' : '52px')}
+  height: ${(props) => (props.isHeadRow ? '56px' : '52px')}
 
-    ${COMMON};
-    ${TYPOGRAPHY};
+  ${COMMON};
+  ${TYPOGRAPHY};
 `;
 
 const TableRow = ({ children, ...props }) => {

--- a/src/theme.js
+++ b/src/theme.js
@@ -92,7 +92,7 @@ const colors = {
   redPalette,
   yellowPalette,
   text: {
-    grayScale: {
+    greyScale: {
       main: typographyColors.charcoal,
       support: typographyColors.iron,
     },


### PR DESCRIPTION
Resolves #80 
Resolves #79 
Resolves #78 

- change Card default size to 318px
- grey and gray lol (will need to fix docs later after we bump version)

### Table typography
- apparently whenever you style `th` or `td` in the `table` css, it overrides all typography styling. So if you tried to have a differnet `fontSize` for one of the table cells, it wouldn't occur. I was wrong to tell eric to move it to the `Table` styling
- so now, we have the default styling in `Table.Body` and `Table.Head`. In this case, you would have the body row with size 18px. but 2 of the cells will be 12px. Same thing with `Table.Head`


```jsx
<Table type="zebra">
          <Head>
            <Row>
              <Cell>First Name</Cell>
              <Cell>Last Name</Cell>
              <Cell>Favorite Color</Cell>
              <Cell>Favorite Number</Cell>
            </Row>
          </Head>
          <Body>
            <Row fontSize="18px">
              <Cell fontSize="12px">Blah</Cell>
              <Cell fontSize="12px">Blah</Cell>
              <Cell>Pink</Cell>
              <Cell>3</Cell>
            </Row>
          </Body>
        </Table>
```