### PR TITLE
Update Card whitespace

### DIFF
--- a/docs/components/CodeBlock.js
+++ b/docs/components/CodeBlock.js
@@ -46,7 +46,7 @@ export default ({
 
   if (live) {
     return (
-      <Box style={{ marginTop: '24px' }}>
+      <Box style={{ marginTop: '24px', whiteSpace: 'pre-wrap' }}>
         <CodeExampleBox>
           <LiveProvider
             code={children.trim()}

--- a/docs/pages/components/cards.mdx
+++ b/docs/pages/components/cards.mdx
@@ -18,7 +18,7 @@ This example includes all Card components, which are: `Image`, `Content`, `Overl
     <Card>
         <Card.Image src="/docs-content/design/cards/BlueRectangle.svg"/>
         <Card.Content>
-            <Card.Overline>Card Title</Card.Overline>
+            <Card.Overline>Optional Overline</Card.Overline>
             <Card.Title>Card Title</Card.Title>
             <Card.Subtitle>Optional Subtitle</Card.Subtitle>
             <Card.Body>

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -986,10 +986,10 @@
   resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
   integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
-"@hack4impact-uiuc/bridge@^0.0.9":
-  version "0.0.9"
-  resolved "https://registry.yarnpkg.com/@hack4impact-uiuc/bridge/-/bridge-0.0.9.tgz#bfb5b1235bdc8dd1467ff308133a1f793bb30616"
-  integrity sha512-wtk46/aTq0NIWD1BxFqgPtHzfyGkQkVdpejDkgsfTlaVI1Xj3P4gsUepxblsBsbyzpnaENHlS6dsZKDcU5+ixw==
+"@hack4impact-uiuc/bridge@^0.1.0":
+  version "0.1.0"
+  resolved "https://registry.yarnpkg.com/@hack4impact-uiuc/bridge/-/bridge-0.1.0.tgz#787dc8793fae32514cab2e789b4d0e200ea27a9a"
+  integrity sha512-0m1HMSzYHrjXuXtMBkaXsBr4VblpU5dTMYeRo7w1XUAXkGUmMniaVQTQ/u09Tq/NLl0gMB3d/Oq5fyVbXg93Zw==
   dependencies:
     "@styled-system/prop-types" "^5.1.5"
     "@styled-system/theme-get" "^5.1.2"

--- a/src/__tests__/__snapshots__/Card.js.snap
+++ b/src/__tests__/__snapshots__/Card.js.snap
@@ -10,6 +10,7 @@ exports[`Card renders a <div> 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  white-space: pre-wrap;
   background-color: #FFFFFF;
   border-radius: 8px;
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.24);
@@ -143,6 +144,7 @@ exports[`Card renders entire card properly 1`] = `
   -webkit-flex-direction: column;
   -ms-flex-direction: column;
   flex-direction: column;
+  white-space: pre-wrap;
   background-color: #FFFFFF;
   border-radius: 8px;
   box-shadow: 0 2px 5px 0 rgba(0,0,0,0.24);

--- a/src/components/Card/Card.js
+++ b/src/components/Card/Card.js
@@ -15,6 +15,8 @@ import Flex from '../Flex';
 const Card = styled(Flex)`
   vertical-align: top;
   flex-direction: column;
+  
+  white-space: pre-wrap;
 
   background-color: ${get('colors.white')};
   border-radius: 8px;


### PR DESCRIPTION
in codeblocks, the white-space property is `pre`, this screws with everything in a `Card`. So a `Card` should set its own `white-space` property so the text won't overflow the card. 